### PR TITLE
Add `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "qunit-clib",
+  "version": "0.1.0",
+  "description": "QUnit CLIB helps extend QUnit's CLI support to many common CLI environments.",
+  "main": "qunit-clib.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jdalton/qunit-clib.git"
+  },
+  "keywords": [
+    "qunit",
+    "cli"
+  ],
+  "author": "John-David Dalton",
+  "readmeFilename": "README.md"
+}


### PR DESCRIPTION
Thought I’d help a bit with #6 since you’re busy IRL :)

I haven’t published anything to npm yet as I didn’t want to squat the `qunit-clib` package name under my username.
