### PR TITLE
Avoid false positive when detecting OS

### DIFF
--- a/qunit-extras.js
+++ b/qunit-extras.js
@@ -177,7 +177,7 @@
     var isSilent = document && !isPhantomPage;
 
     /** Used to indicate if running in Windows */
-    var isWindows = /win/i.test(os);
+    var isWindows = /\bwin/i.test(os);
 
     /** Used to display the wait throbber */
     var throbberId,


### PR DESCRIPTION
`process.platform` in Node returns `'darwin'` on OS X, and then, `isWindows = /win/i.test(os)` becomes `true`. Adding a word boundary works around the issue.

Ref. #11.
