### PR TITLE
Match npm’s color scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,11 @@
   "files": [
     "LICENSE.txt",
     "qunit-extras.js"
-  ]
+  ],
+  "devDependencies": {
+    "qunitjs": "~1.11.0"
+  },
+  "scripts": {
+    "test": "node test/test.js"
+  }
 }

--- a/qunit-extras.js
+++ b/qunit-extras.js
@@ -24,10 +24,12 @@
       reMessage = /^<span class='test-message'>([\s\S]*?)<\/span>/;
 
   /** Used to associate color names with their corresponding codes */
-  var colorCodes = {
-    'blue': 34,
+  var ansiCodes = {
+    'bold': 1,
     'green': 32,
-    'red': 31
+    'magenta': 35,
+    'red': 31,
+    'white': 37
   };
 
   /** Used to convert HTML entities to characters */
@@ -276,10 +278,10 @@
      * @returns {string} Returns the colored string.
      */
     function color(colorName, string) {
-      var code = colorCodes[colorName];
+      var code = ansiCodes[colorName];
       return isWindows
         ? string
-        : ('\x1b[' + code + 'm' + string + '\x1b[0m');
+        : ('\x1B[' + code + 'm' + string + '\x1B[0m');
     }
 
     /**
@@ -455,11 +457,11 @@
           ran = true;
 
           var failures = details.failed;
-
+          var statusColor = failures ? 'magenta' : 'green';
           logInline('');
           console.log(hr);
-          console.log(color('blue', '    PASS: ' + details.passed + '  FAIL: ' + failures + '  TOTAL: ' + details.total));
-          console.log(color(failures ? 'red' : 'green','    Finished in ' + details.runtime + ' milliseconds.'));
+          console.log(color(statusColor, '    PASS: ' + details.passed + '  FAIL: ' + failures + '  TOTAL: ' + details.total));
+          console.log(color(statusColor, '    Finished in ' + details.runtime + ' milliseconds.'));
           console.log(hr);
 
           // exit out of Node.js or PhantomJS
@@ -519,10 +521,10 @@
         if (!modulePrinted) {
           modulePrinted = true;
           console.log(hr);
-          console.log(color('blue', moduleName));
+          console.log(color('bold', moduleName));
           console.log(hr);
         }
-        console.log(' ' + (failures ? color('red', 'FAIL') : color('green', 'PASS')) + ' - ' + color('blue', testName));
+        console.log(' ' + (failures ? color('red', 'FAIL') : color('green', 'PASS')) + ' - ' + testName);
 
         if (!failures) {
           return;
@@ -541,12 +543,12 @@
 
           var message = [
             result ? color('green', 'PASS') : color('red', 'FAIL'),
-            color('blue', type),
-            color('blue', entry.message || 'ok')
+            type,
+            entry.message || 'ok'
           ];
 
           if (!result && type == 'EQ') {
-            message.push(color('blue', 'Expected: ' + expected + ', Actual: ' + entry.actual));
+            message.push(color('magenta', 'Expected: ' + expected + ', Actual: ' + entry.actual));
           }
           console.log('    ' + message.join(' | '));
         }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,52 @@
+(function() {
+
+  // used as reference to the global object
+  var root = typeof global == 'object' && global || this;
+
+  // used as a no-op function
+  var noop = Function.prototype;
+
+  // use a single "load" function
+  var load = (typeof require == 'function' && !(root.define && define.amd))
+    ? require
+    : (!root.document && root.java && root.load) || noop;
+
+  // load QUnit in a way to workaround cross-environment issues
+  var QUnit = (function() {
+    return  root.QUnit || (
+      root.addEventListener || (root.addEventListener = noop),
+      root.setTimeout || (root.setTimeout = noop),
+      root.QUnit = load('../node_modules/qunitjs/qunit/qunit.js') || root.QUnit,
+      addEventListener === noop && delete root.addEventListener,
+      root.QUnit
+    );
+  }());
+
+  // load and install QUnit Extras
+  var qe = load('../qunit-extras.js');
+  if (qe) {
+    qe.runInContext(root);
+  }
+
+  // call `QUnit.module()` instead of `module()` when in a CLI
+  QUnit.module('qunit-extras');
+
+  test('Some test with a title', function() {
+    equal(1, 1, 'foo');
+    equal(2, 2, 'bar');
+    equal('a', 'a', 'baz');
+    equal('b', 'b', 'qux');
+  });
+
+  test('Some other test with a title', function() {
+    equal(1, 2, 'foo');
+    equal(2, 2, 'bar');
+    equal('a', 'a', 'baz');
+    equal('b', 'b', 'qux');
+  });
+
+  // call `QUnit.start()` when in a CLI or PhantomJS
+  if (!root.document || root.phantom) {
+    QUnit.start();
+  }
+}.call(this));


### PR DESCRIPTION
I’ve made the colors match npm’s color scheme. It’s more consistent, but IMHO it looks better too.

Before:

![](https://cloud.githubusercontent.com/assets/81942/2788432/6ec51c2c-cb9b-11e3-9219-87d271169ddd.png)

After:

![](https://cloud.githubusercontent.com/assets/81942/2788420/4de7d22e-cb9b-11e3-9ba5-14a906010f81.png)

Note that I also added example tests, so this patch closes #13.
